### PR TITLE
fix: Apply patch to fix infinite loop/crash

### DIFF
--- a/weasyprint/layout/inlines.py
+++ b/weasyprint/layout/inlines.py
@@ -792,9 +792,6 @@ def split_inline_box(context, box, position_x, max_x, skip_stack,
                         # TODO: should we also accept relative children?
                         if (child.is_in_normal_flow() and
                                 can_break_inside(child)):
-                            # This waiting child is in flow and can be broken,
-                            # let's break it!
-                            break_found = True
 
                             # We break the waiting child at its last possible
                             # breaking point.
@@ -810,6 +807,20 @@ def split_inline_box(context, box, position_x, max_x, skip_stack,
                                     absolute_boxes, fixed_boxes,
                                     line_placeholders, waiting_floats,
                                     line_children))
+                            
+                            # Applied patch https://github.com/Kozea/WeasyPrint/commit/c9d1a59adc8152c236677894baa6f5ca1c3d9642
+                            # As PangoLayout and PangoLogAttr don't always
+                            # agree, we have to rely on the actual split to
+                            # know whether the child was broken.
+                            # https://github.com/Kozea/WeasyPrint/issues/614
+                            break_found = child_resume_at is not None
+                            if child_resume_at is None:
+                                # PangoLayout decided not to break the child
+                                child_resume_at = (0, None)
+                            # TODO: use this when Pango is always 1.40.13+:
+                            # break_found = True
+
+
                             children = children + waiting_children_copy
                             if child_new_child is None:
                                 # May be None where we have an empty TextBox.

--- a/weasyprint/layout/inlines.py
+++ b/weasyprint/layout/inlines.py
@@ -808,6 +808,7 @@ def split_inline_box(context, box, position_x, max_x, skip_stack,
                                     line_placeholders, waiting_floats,
                                     line_children))
                             
+                            
                             # Applied patch https://github.com/Kozea/WeasyPrint/commit/c9d1a59adc8152c236677894baa6f5ca1c3d9642
                             # As PangoLayout and PangoLogAttr don't always
                             # agree, we have to rely on the actual split to
@@ -817,8 +818,6 @@ def split_inline_box(context, box, position_x, max_x, skip_stack,
                             if child_resume_at is None:
                                 # PangoLayout decided not to break the child
                                 child_resume_at = (0, None)
-                            # TODO: use this when Pango is always 1.40.13+:
-                            # break_found = True
 
 
                             children = children + waiting_children_copy


### PR DESCRIPTION
- Applied patch https://github.com/Kozea/WeasyPrint/commit/c9d1a59adc8152c236677894baa6f5ca1c3d9642.
- Fixes `'NoneType' object is not iterable` error.